### PR TITLE
feat(app): enqueue transcode via Kafka (멱등 jobKey + DB 기록)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,10 @@ dependencies {
     //Kafka
     implementation("org.springframework.kafka:spring-kafka")
 
+    //Lombok
+    compileOnly("org.projectlombok:lombok:1.18.34")
+    annotationProcessor("org.projectlombok:lombok:1.18.34")
+
 
 
     // Test
@@ -40,4 +44,7 @@ dependencies {
     testImplementation("org.testcontainers:mysql:1.20.1")
     testImplementation("com.redis:testcontainers-redis:2.2.4")
     testImplementation("io.lettuce:lettuce-core:6.4.0.RELEASE")
+    testImplementation("org.testcontainers:kafka:1.19.7")
+    testImplementation("org.testcontainers:junit-jupiter:1.19.7")
+
 }

--- a/app/src/main/java/com/example/app/config/KafkaProducerConfig.java
+++ b/app/src/main/java/com/example/app/config/KafkaProducerConfig.java
@@ -1,0 +1,42 @@
+package com.example.app.config;
+
+import com.example.app.messaging.TranscodeRequestedEvent;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.*;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+@Configuration
+@EnableConfigurationProperties(KafkaTopicsProperties.class)
+public class KafkaProducerConfig {
+    @Bean
+    public ProducerFactory<String, TranscodeRequestedEvent> transcodeProducerFactory(KafkaProperties props) {
+        Map<String,Object> cfg = props.buildProducerProperties(null);
+        cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(cfg);
+    }
+    @Bean
+    public KafkaTemplate<String, TranscodeRequestedEvent> transcodeKafkaTemplate(
+            ProducerFactory<String, TranscodeRequestedEvent> pf) {
+        return new KafkaTemplate<>(pf);
+    }
+    @Bean
+    public NewTopic transcodeRequestsTopic(KafkaTopicsProperties tp) {
+        return TopicBuilder.name(tp.transcodeRequests()).partitions(3).replicas(1).build();
+    }
+}
+@ConfigurationProperties(prefix = "app.topics")
+class KafkaTopicsProperties {
+    private String transcodeRequests;
+    public String transcodeRequests() { return transcodeRequests; }
+    public void setTranscodeRequests(String v){ this.transcodeRequests = v; }
+}

--- a/app/src/main/java/com/example/app/controller/TranscodeEnqueueController.java
+++ b/app/src/main/java/com/example/app/controller/TranscodeEnqueueController.java
@@ -1,0 +1,44 @@
+package com.example.app.controller;
+
+import com.example.app.service.TranscodeEnqueueService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Transcode")
+@RestController
+@RequestMapping("/videos/{videoId}/enqueue-transcode")
+public class TranscodeEnqueueController {
+
+    private final TranscodeEnqueueService service;
+
+    public TranscodeEnqueueController(TranscodeEnqueueService service) {
+        this.service = service;
+    }
+
+    public record EnqueueRequest(@NotEmpty List<String> variants) {}
+    public record EnqueueResponse(Long jobId, String jobKey, String status, boolean created) {}
+
+    @Operation(summary = "트랜스코딩 작업 큐 투입(멱등)",
+            description = "Idempotency-Key 헤더가 같으면 중복 생성 없이 동일 작업을 반환합니다.")
+    @PostMapping
+    public EnqueueResponse enqueue(@PathVariable Long videoId,
+                                   @RequestBody EnqueueRequest req,
+                                   @RequestHeader(value = "Idempotency-Key", required = false) String idemKey) {
+        // 기본 출력 경로 규칙(예: videos/{videoId}/hls/)
+        String targetPrefix = "videos/%d/hls/".formatted(videoId);
+
+        var r = service.enqueue(
+                videoId,
+                (req.variants() == null || req.variants().isEmpty())
+                        ? List.of("480p", "720p", "1080p")
+                        : req.variants(),
+                targetPrefix,
+                idemKey
+        );
+        return new EnqueueResponse(r.jobId(), r.jobKey(), r.status(), r.created());
+    }
+}

--- a/app/src/main/java/com/example/app/domain/TranscodeJob.java
+++ b/app/src/main/java/com/example/app/domain/TranscodeJob.java
@@ -1,0 +1,96 @@
+package com.example.app.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "transcode_job",
+        uniqueConstraints = @UniqueConstraint(name = "uk_job_key", columnNames = "job_key"),
+        indexes = { @Index(name = "ix_video_id", columnList = "video_id") })
+public class TranscodeJob {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "job_key", nullable = false, length = 50)
+    private String jobKey;
+
+    @Column(name = "video_id", nullable = false)
+    private Long videoId;
+
+    @Column(name = "target_prefix", nullable = false, length = 255)
+    private String targetPrefix; // 예: videos/{videoId}/hls/
+
+    @Column(name = "variants_json", nullable = false, columnDefinition = "JSON")
+    private String variantsJson; // ["480p","720p","1080p"]
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private Status status = Status.QUEUED;
+
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount = 0;
+
+    @Column(name = "last_error")
+    private String lastError;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private int version; // 낙관적 락
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    protected TranscodeJob() {}
+
+    private TranscodeJob(String jobKey, Long videoId, String targetPrefix, String variantsJson) {
+        this.jobKey = jobKey;
+        this.videoId = videoId;
+        this.targetPrefix = targetPrefix;
+        this.variantsJson = variantsJson;
+        this.status = Status.QUEUED;
+    }
+
+    public static TranscodeJob queued(Long videoId, String jobKey, String targetPrefix, String variantsJson) {
+        return new TranscodeJob(jobKey, videoId, targetPrefix, variantsJson);
+    }
+
+    // 상태 전이 헬퍼 (추후 서비스에서 사용)
+    public void markRunning() {
+        this.status = Status.RUNNING;
+        this.updatedAt = LocalDateTime.now();
+    }
+    public void markSuccess() {
+        this.status = Status.SUCCESS;
+        this.updatedAt = LocalDateTime.now();
+    }
+    public void markFailed(String error, LocalDateTime nextRetryAt) {
+        this.status = Status.FAILED;
+        this.lastError = error;
+        this.nextRetryAt = nextRetryAt;
+        this.updatedAt = LocalDateTime.now();
+    }
+    public void incAttempt() {
+        this.attemptCount++;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public enum Status { QUEUED, RUNNING, SUCCESS, FAILED, CANCELLED }
+
+    // 최소 getter (서비스/리스너에서 필요해요)
+    public Long getId() { return id; }
+    public String getJobKey() { return jobKey; }
+    public Long getVideoId() { return videoId; }
+    public String getTargetPrefix() { return targetPrefix; }
+    public String getVariantsJson() { return variantsJson; }
+    public Status getStatus() { return status; }
+    public int getAttemptCount() { return attemptCount; }
+    public String getLastError() { return lastError; }
+    public LocalDateTime getNextRetryAt() { return nextRetryAt; }
+}

--- a/app/src/main/java/com/example/app/messaging/TranscodeProducer.java
+++ b/app/src/main/java/com/example/app/messaging/TranscodeProducer.java
@@ -1,0 +1,25 @@
+package com.example.app.messaging;
+
+import org.springframework.kafka.support.SendResult;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class TranscodeProducer {
+    private final KafkaTemplate<String, TranscodeRequestedEvent> kt;
+    private final String topic;
+    public TranscodeProducer(KafkaTemplate<String, TranscodeRequestedEvent> kt,
+                             @Value("${app.topics.transcode-requests}") String topic) {
+        this.kt = kt; this.topic = topic;
+    }
+    public CompletableFuture<SendResult<String,TranscodeRequestedEvent>>
+    publish(Long jobId, Long videoId, String jobKey, String targetPrefix, List<String> variants) {
+        var event = new TranscodeRequestedEvent(jobId, videoId, jobKey, targetPrefix, variants, OffsetDateTime.now());
+        return kt.send(topic, jobKey, event);
+    }
+}

--- a/app/src/main/java/com/example/app/messaging/TranscodeRequestedEvent.java
+++ b/app/src/main/java/com/example/app/messaging/TranscodeRequestedEvent.java
@@ -1,0 +1,9 @@
+package com.example.app.messaging;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record TranscodeRequestedEvent(
+        Long jobId, Long videoId, String jobKey, String targetPrefix,
+        List<String> variants, OffsetDateTime requestedAt
+) {}

--- a/app/src/main/java/com/example/app/repo/TranscodeJobRepository.java
+++ b/app/src/main/java/com/example/app/repo/TranscodeJobRepository.java
@@ -1,0 +1,20 @@
+package com.example.app.repo;
+
+import com.example.app.domain.TranscodeJob;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface TranscodeJobRepository extends JpaRepository<TranscodeJob, Long> {
+
+    Optional<TranscodeJob> findByJobKey(String jobKey);
+
+    boolean existsByJobKey(String jobKey);
+
+    // 워커에서 안전하게 한 건을 집어 처리하고 싶을 때
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select j from TranscodeJob j where j.jobKey = :jobKey")
+    Optional<TranscodeJob> findByJobKeyForUpdate(@Param("jobKey") String jobKey);
+}

--- a/app/src/main/java/com/example/app/service/TranscodeEnqueueService.java
+++ b/app/src/main/java/com/example/app/service/TranscodeEnqueueService.java
@@ -1,0 +1,63 @@
+package com.example.app.service;
+
+import com.example.app.domain.TranscodeJob;
+import com.example.app.repo.TranscodeJobRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class TranscodeEnqueueService {
+
+    private final TranscodeJobRepository jobRepo;
+    private final ObjectMapper om;
+
+    public TranscodeEnqueueService(TranscodeJobRepository jobRepo, ObjectMapper om) {
+        this.jobRepo = jobRepo;
+        this.om = om;
+    }
+
+    /** 클라이언트가 보낸 Idempotency-Key가 있으면 사용, 없으면 새 UUID 생성 */
+    private String resolveJobKey(String idempotencyKeyHeader) {
+        String key = (idempotencyKeyHeader == null || idempotencyKeyHeader.isBlank())
+                ? UUID.randomUUID().toString()
+                : idempotencyKeyHeader.trim();
+        // DB 스키마가 VARCHAR(50) 이므로 방어적 클램프
+        if (key.length() > 50) key = key.substring(0, 50);
+        return key;
+    }
+
+    public record EnqueueResult(Long jobId, String jobKey, String status, boolean created) {}
+
+    @Transactional
+    public EnqueueResult enqueue(Long videoId,
+                                 List<String> variants,
+                                 String targetPrefix,
+                                 String idempotencyKeyHeader) {
+        String jobKey = resolveJobKey(idempotencyKeyHeader);
+
+        // 1) 같은 jobKey로 이미 생성된 작업이 있으면 그대로 반환(멱등)
+        var existing = jobRepo.findByJobKey(jobKey);
+        if (existing.isPresent()) {
+            var j = existing.get();
+            return new EnqueueResult(j.getId(), j.getJobKey(), j.getStatus().name(), false);
+        }
+
+        // 2) 없으면 새로 저장
+        String variantsJson;
+        try {
+            variantsJson = om.writeValueAsString(variants);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("variants 직렬화 실패", e);
+        }
+
+        TranscodeJob j = jobRepo.save(
+                TranscodeJob.queued(videoId, jobKey, targetPrefix, variantsJson)
+        );
+        return new EnqueueResult(j.getId(), j.getJobKey(), j.getStatus().name(), true);
+    }
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -63,9 +63,8 @@ management:
 storage:
   endpoint: http://localhost:9000
   bucket: media
-  accessKey: minio
-  secretKey: minio123
-
+  accessKey: minioadmin
+  secretKey: minioadmin123
 
 
 server:


### PR DESCRIPTION
## Summary
`POST /videos/{id}/enqueue-transcode` 호출 시
- 멱등 `jobKey`로 `transcode_job`을 **DB에 기록**하고,
- Kafka **transcode-requests** 토픽으로 이벤트를 **afterCommit** 시점에 발행합니다.

## Background
- 업로드된 원본 영상에 대해 트랜스코딩 작업을 큐에 안전하게 투입
- 중복 요청/네트워크 재시도에도 **멱등 보장**
- 워커(Consumer) 구현 전, Producer/DB 파트 안정화

## Changes
### DB
- `transcode_job` 테이블 신설
- `job_key` UNIQUE (멱등키)
- `video_id` FK(`video.id`) ON DELETE CASCADE
- 상태/재시도(`status/attempt_count/last_error/next_retry_at`)
- `version`(낙관적 락), `created_at/updated_at`

### Domain/Repository
- `TranscodeJob` 엔티티 (+ 상태 전이 헬퍼)
- `TranscodeJobRepository` (`findByJobKey`, `existsByJobKey`)

### Service
- `TranscodeEnqueueService`
  - `Idempotency-Key` 헤더 우선, 미제공 시 서버가 **UUID** 생성
  - 이미 존재하는 `jobKey`면 **그 Job 그대로 반환**(created=false)
  - `videoId` 존재 선확인 → 없으면 **404 VIDEO_NOT_FOUND**
  - **afterCommit** 훅으로 커밋 확정 뒤에만 Kafka 발행

### Messaging (Kafka)
- `TranscodeRequestedEvent` (record DTO)
- `KafkaProducerConfig` (ProducerFactory/KafkaTemplate, 토픽 자동 생성)
- `TranscodeProducer` (키=jobKey로 발행)
- 설정: `spring.kafka.bootstrap-servers=localhost:9094`, `acks=all`, `enable.idempotence=true`
- 토픽: `app.topics.transcode-requests=transcode-requests-v1`

### API
- `POST /videos/{videoId}/enqueue-transcode`
  - Header: `Idempotency-Key` (optional)
  - Body:
    ```json
    { "variants": ["480p", "720p"] }
    ```
  - 200 응답:
    ```json
    { "jobId": 10, "jobKey": "job-2025-09-05-001", "status": "QUEUED", "created": true }
    ```
  - 404 응답:
    ```json
    { "status": 404, "code": "VIDEO_NOT_FOUND", "message": "video not found: 123" }
    ```