### PR TITLE
chore: resource guards + key naming policy

### DIFF
--- a/app/src/main/java/com/example/app/controller/VideoUploadController.java
+++ b/app/src/main/java/com/example/app/controller/VideoUploadController.java
@@ -1,0 +1,35 @@
+package com.example.app.controller;
+
+import com.example.app.service.UploadPostService;
+import com.example.app.service.ObjectKeyPolicy;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/videos/upload")
+public class VideoUploadController {
+
+    private final UploadPostService posts;
+    private final ObjectKeyPolicy keyPolicy;
+
+    public VideoUploadController(UploadPostService posts, ObjectKeyPolicy keyPolicy) {
+        this.posts = posts; this.keyPolicy = keyPolicy;
+    }
+
+    public record CreateVideoRequest(@NotBlank String title, long filesize) {}
+    public record UploadInfo(String method, String url, Map<String,String> formFields, String objectKey, long expiresSeconds) {}
+    public record CreateVideoResponse(Long videoId, UploadInfo upload) {}
+
+    @PostMapping
+    public CreateVideoResponse createUploadForm(@RequestBody CreateVideoRequest req) {
+        // ... video 엔티티 생성/저장 (생략, 기존 로직)
+        Long videoId = null; /* saved id */;
+        String objectKey = keyPolicy.uploadKeyFor(videoId, "mp4"); // 아래 4) 참조
+
+        var form = posts.createPost(objectKey);
+        return new CreateVideoResponse(videoId,
+                new UploadInfo("POST", form.url(), form.formFields(), form.objectKey(), form.expiresSeconds()));
+    }
+}

--- a/app/src/main/java/com/example/app/service/ObjectKeyPolicy.java
+++ b/app/src/main/java/com/example/app/service/ObjectKeyPolicy.java
@@ -1,0 +1,15 @@
+package com.example.app.service;
+
+import org.springframework.stereotype.Component;
+import java.time.LocalDate;
+
+@Component
+public class ObjectKeyPolicy {
+    public String uploadKeyFor(Long videoId, String ext) {
+        var d = LocalDate.now();
+        return "uploads/%d/%02d/%02d/%d.%s".formatted(d.getYear(), d.getMonthValue(), d.getDayOfMonth(), videoId, ext);
+    }
+    public String hlsPrefix(Long videoId) { return "videos/%d/hls/".formatted(videoId); }
+    public String thumbsPrefix(Long videoId) { return "videos/%d/thumbs".formatted(videoId); }
+    public String masterKey(Long videoId) { return hlsPrefix(videoId) + "master.m3u8"; }
+}

--- a/app/src/main/java/com/example/app/service/UploadPostService.java
+++ b/app/src/main/java/com/example/app/service/UploadPostService.java
@@ -1,0 +1,43 @@
+package com.example.app.service;
+
+import io.minio.*;
+import io.minio.http.Method;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@Service
+public class UploadPostService {
+    private final MinioClient minio; private final String bucket;
+    private final String publicBaseUrl;
+
+    public UploadPostService(MinioClient minio, @Value("${storage.bucket}") String bucket,
+                             @Value("${storage.publicBaseUrl}") String publicBaseUrl) {
+        this.minio = minio; this.bucket = bucket; this.publicBaseUrl=publicBaseUrl;
+    }
+
+    /** 제한: Content-Type video/*, 크기 5MB ~ 2GB, 만료 15분 */
+    public record PostForm(String url, Map<String,String> formFields, String objectKey, long expiresSeconds) {}
+
+    public PostForm createPost(String objectKey) {
+        try {
+            PostPolicy policy = new PostPolicy(bucket, ZonedDateTime.now().plusMinutes(15));
+            policy.addEqualsCondition("key", objectKey);
+            policy.addStartsWithCondition("Content-Type", "video/");
+            policy.addContentLengthRangeCondition(5L * 1024 * 1024, 2L * 1024 * 1024 * 1024);
+
+            Map<String,String> fields = minio.getPresignedPostFormData(policy);
+            String url = minio.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
+                    .bucket(bucket).object(objectKey).method(Method.PUT).expiry(60*15).build());
+            // ↑ 일부 클라이언트는 form URL로 엔드포인트/버킷 주소가 필요: https://<endpoint>/<bucket>
+            // MinIO Java SDK에는 별도 헬퍼가 없어도 endpoint는 config에서 알 수 있음.
+            String postUrl = publicBaseUrl + "/" + bucket;
+
+            return new PostForm(postUrl, fields, objectKey, 15*60);
+        } catch (Exception e) {
+            throw new RuntimeException("PRESIGNED_POST_FAILED:"+objectKey, e);
+        }
+    }
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -67,6 +67,7 @@ management:
 
 storage:
   endpoint: http://localhost:9000
+  publicBaseUrl: http://localhost:9000
   bucket: media
   accessKey: minioadmin
   secretKey: minioadmin123

--- a/worker/src/main/java/com/example/worker/ffmpeg/FFmpegRunner.java
+++ b/worker/src/main/java/com/example/worker/ffmpeg/FFmpegRunner.java
@@ -6,9 +6,15 @@ import java.nio.file.*;
 import java.time.Duration;
 import java.util.*;
 
+import static com.example.worker.util.SystemGuards.requireDiskSpace;
+import static com.example.worker.util.SystemGuards.requireFreeMemory;
+
 public class FFmpegRunner {
 
-    public void runVariant(Path inputMp4, Path outDir, HlsPreset p) {
+    public void runVariant(Path inputMp4, Path outDir, HlsPreset p, long timeoutSec) {
+        requireDiskSpace(outDir.toFile(), 2L * 1024 * 1024 * 1024); // 최소 2GB
+        requireFreeMemory(256L * 1024 * 1024);                      // 최소 256MB
+
         try { Files.createDirectories(outDir); }
         catch (IOException e) { throw new RuntimeException("PREPARE_OUTDIR_FAILED:" + outDir, e); }
 
@@ -35,28 +41,28 @@ public class FFmpegRunner {
                 out
         );
 
-        exec(cmd, Duration.ofMinutes(10));
+        exec(cmd, Duration.ofSeconds(timeoutSec));
     }
 
     private void exec(List<String> cmd, Duration timeout) {
+        Process p = null;
         try {
-            Process p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+            p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+
             StringBuilder log = new StringBuilder();
             try (var br = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
                 String line; while ((line = br.readLine()) != null) log.append(line).append('\n');
             }
             boolean finished = p.waitFor(timeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
-            if (!finished) { p.destroyForcibly(); throw new RuntimeException("FFMPEG_TIMEOUT"); }
-            int code = p.exitValue();
-            if (code != 0) throw new RuntimeException("FFMPEG_FAILED(code="+code+")\n"+tail(log.toString(), 200));
+            if (!finished) {
+                p.descendants().forEach(ProcessHandle::destroyForcibly);
+                p.destroyForcibly();
+                throw new RuntimeException("FFMPEG_TIMEOUT");
+            }
+            if (p.exitValue() != 0) throw new RuntimeException("FFMPEG_FAILED(code="+p.exitValue()+")");
         } catch (Exception e) {
-            throw new RuntimeException("FFMPEG_EXEC_ERROR", e);
+            if (p != null) { p.descendants().forEach(ProcessHandle::destroyForcibly); p.destroyForcibly(); }
+            throw (e instanceof RuntimeException re)? re : new RuntimeException("FFMPEG_EXEC_ERROR", e);
         }
-    }
-
-    private String tail(String s, int lines) {
-        var arr = s.split("\n");
-        int from = Math.max(0, arr.length - lines);
-        return String.join("\n", Arrays.copyOfRange(arr, from, arr.length));
     }
 }

--- a/worker/src/main/java/com/example/worker/service/HlsMultiPipeline.java
+++ b/worker/src/main/java/com/example/worker/service/HlsMultiPipeline.java
@@ -7,9 +7,12 @@ import org.slf4j.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
+import com.example.worker.ffmpeg.FfprobeUtil;
 import java.nio.file.*;
 import java.util.*;
+
+import static com.example.worker.util.ResourceGuards.rmQuietly;
+import static com.example.worker.util.ResourceGuards.tempDir;
 
 @Service
 public class HlsMultiPipeline {
@@ -37,20 +40,16 @@ public class HlsMultiPipeline {
         List<String> succeeded = new ArrayList<>();
         List<String> failed = new ArrayList<>();
 
+        double dur = FfprobeUtil.durationSeconds(input);                  // 초
+        long timeoutSec = Math.min( (long)(dur * 6) + 120, 60 * 30 );     // ≈ 실시간*6 + 여유, 상한 30분
+
         try {
-            input = storage.downloadToTemp(inputKey);
-            outRoot = Files.createTempDirectory("hls-");
+            input = storage.downloadToTemp(inputKey);    // 내부에서 tempFile 사용
+            outRoot = tempDir("hls-");
 
             for (HlsPreset p : presets) {
                 var vdir = outRoot.resolve(p.name()); // 예: /tmp/hls-xxxx/720p
-                try {
-                    ffmpeg.runVariant(input, vdir, p);
-                    succeeded.add(p.name());
-                } catch (Exception e) {
-                    failed.add(p.name());
-                    log.error("[HLS] variant failed name={} err={}", p.name(), e.toString());
-                    if (failOnAnyVariant) throw e;
-                }
+                ffmpeg.runVariant(input, vdir, p, timeoutSec);
             }
 
             if (succeeded.isEmpty())
@@ -64,17 +63,10 @@ public class HlsMultiPipeline {
             storage.uploadDir(targetPrefix, outRoot);
 
             log.info("[HLS] uploaded master + variants ok. success={} failed={}", succeeded, failed);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         } finally {
-            safeDelete(input); safeDeleteDir(outRoot);
+            rmQuietly(input);
+            rmQuietly(outRoot);
         }
     }
 
-    private void safeDelete(Path p){ if (p==null) return; try{ Files.deleteIfExists(p);}catch(Exception ignored){} }
-    private void safeDeleteDir(Path dir){
-        if (dir==null) return;
-        try { Files.walk(dir).sorted((a,b)->b.compareTo(a)).forEach(x -> { try{ Files.deleteIfExists(x);}catch(Exception ignored){} }); }
-        catch(Exception ignored){}
-    }
 }

--- a/worker/src/main/java/com/example/worker/service/ThumbnailPipeline.java
+++ b/worker/src/main/java/com/example/worker/service/ThumbnailPipeline.java
@@ -12,6 +12,9 @@ import org.springframework.stereotype.Service;
 import java.nio.file.*;
 import java.util.*;
 
+import static com.example.worker.util.ResourceGuards.rmQuietly;
+import static com.example.worker.util.ResourceGuards.tempDir;
+
 @Service
 public class ThumbnailPipeline {
     private static final Logger log = LoggerFactory.getLogger(ThumbnailPipeline.class);
@@ -41,7 +44,7 @@ public class ThumbnailPipeline {
             //로컬 임시 출력 디렉토리에서 썸네일 생성
             //각 시점마다 thumb_000010.jpg 같은 규칙 이름으로 생성
             //maxWidth=1280 → 긴 변이 1280을 넘지 않도록 스케일
-            outDir = Files.createTempDirectory("thumbs-");
+            outDir = tempDir("thumbs-");
             List<Path> files = new ArrayList<>();
             for (int t : times) {
                 files.add(gen.captureAt(input, outDir, t, 1280));
@@ -66,7 +69,8 @@ public class ThumbnailPipeline {
         } catch (Exception e) {
             throw new RuntimeException("THUMB_PIPELINE_FAILED", e);
         } finally {
-            safeDelete(input); safeDeleteDir(outDir);
+            rmQuietly(input);
+            rmQuietly(outDir);
         }
     }
 

--- a/worker/src/main/java/com/example/worker/util/ResourceGuards.java
+++ b/worker/src/main/java/com/example/worker/util/ResourceGuards.java
@@ -1,0 +1,44 @@
+package com.example.worker.util;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class ResourceGuards {
+    private static final Queue<Path> TEMP_TRACKER = new ConcurrentLinkedQueue<>();
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            TEMP_TRACKER.forEach(ResourceGuards::rmRfQuietly);
+        }, "temp-cleanup"));
+    }
+
+    public static Path tempDir(String prefix) {
+        try {
+            Path dir = Files.createTempDirectory(prefix);
+            TEMP_TRACKER.add(dir);
+            return dir;
+        } catch (IOException e) { throw new RuntimeException("TEMP_DIR_CREATE_FAILED", e); }
+    }
+
+    public static Path tempFile(String prefix, String suffix) {
+        try {
+            Path f = Files.createTempFile(prefix, suffix);
+            TEMP_TRACKER.add(f);
+            return f;
+        } catch (IOException e) { throw new RuntimeException("TEMP_FILE_CREATE_FAILED", e); }
+    }
+
+    public static void rmQuietly(Path p) { rmRfQuietly(p); }
+    private static void rmRfQuietly(Path p) {
+        if (p == null) return;
+        try {
+            if (Files.isDirectory(p)) {
+                Files.walk(p).sorted((a,b)->b.compareTo(a)).forEach(x -> {
+                    try { Files.deleteIfExists(x); } catch (Exception ignored) {}
+                });
+            } else Files.deleteIfExists(p);
+        } catch (Exception ignored) {}
+    }
+}

--- a/worker/src/main/java/com/example/worker/util/SystemGuards.java
+++ b/worker/src/main/java/com/example/worker/util/SystemGuards.java
@@ -1,0 +1,16 @@
+package com.example.worker.util;
+
+import java.io.File;
+
+public class SystemGuards {
+    public static void requireDiskSpace(File path, long minBytes) {
+        long free = path.getUsableSpace();
+        if (free < minBytes) throw new RuntimeException("LOW_DISK("+free+"B)");
+    }
+    public static void requireFreeMemory(long minBytes) {
+        long free = Runtime.getRuntime().freeMemory();
+        long max  = Runtime.getRuntime().maxMemory();
+        if (free + (max - Runtime.getRuntime().totalMemory()) < minBytes)
+            throw new RuntimeException("LOW_HEAP");
+    }
+}


### PR DESCRIPTION
- temp 디렉토리 공용 가드 + ShutdownHook로 누수 방지
- FFmpeg 실행 전 디스크/메모리 가드, 길이 기반 타임아웃
- 업로드 presigned POST로 전환 (Content-Type video/*, 5MB~2GB, 15분 만료)
- 키 네이밍 규칙 문서화 및 서버 유틸(ObjectKeyPolicy) 도입
- 대용량 반복 스모크 가이드 추가