### PR TITLE
docs: swagger + error map + runbook

### DIFF
--- a/app/src/main/java/com/example/app/config/OpenApiConfig.java
+++ b/app/src/main/java/com/example/app/config/OpenApiConfig.java
@@ -1,0 +1,17 @@
+package com.example.app.config;
+
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.info.*;
+import org.springframework.context.annotation.*;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("OTT Transcoding API")
+                        .version("v1")
+                        .description("Uploads, transcode enqueue, video details"));
+    }
+}

--- a/app/src/main/java/com/example/app/controller/TranscodeEnqueueController.java
+++ b/app/src/main/java/com/example/app/controller/TranscodeEnqueueController.java
@@ -2,6 +2,10 @@ package com.example.app.controller;
 
 import com.example.app.service.TranscodeEnqueueService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotEmpty;
 import org.springframework.web.bind.annotation.*;
@@ -22,8 +26,18 @@ public class TranscodeEnqueueController {
     public record EnqueueRequest(@NotEmpty List<String> variants) {}
     public record EnqueueResponse(Long jobId, String jobKey, String status, boolean created) {}
 
-    @Operation(summary = "트랜스코딩 작업 큐 투입(멱등)",
-            description = "Idempotency-Key 헤더가 같으면 중복 생성 없이 동일 작업을 반환합니다.")
+    @Operation(summary="Enqueue transcode job", description="variants 지정 후 큐 투입")
+    @ApiResponses({
+            @ApiResponse(responseCode="200", description="enqueued"),
+            @ApiResponse(responseCode="401", description="unauthorized",
+                    content=@Content(schema=@Schema(implementation=com.example.app.error.ErrorResponse.class))),
+            @ApiResponse(responseCode="404", description="video not found",
+                    content=@Content(schema=@Schema(implementation=com.example.app.error.ErrorResponse.class))),
+            @ApiResponse(responseCode="409", description="idempotency conflict",
+                    content=@Content(schema=@Schema(implementation=com.example.app.error.ErrorResponse.class))),
+            @ApiResponse(responseCode="429", description="rate limited",
+                    content=@Content(schema=@Schema(implementation=com.example.app.error.ErrorResponse.class)))
+    })
     @PostMapping
     public EnqueueResponse enqueue(@PathVariable Long videoId,
                                    @RequestBody EnqueueRequest req,

--- a/app/src/main/java/com/example/app/controller/VideoQueryController.java
+++ b/app/src/main/java/com/example/app/controller/VideoQueryController.java
@@ -3,6 +3,11 @@ package com.example.app.controller;
 import com.example.app.repo.ThumbnailRepository;
 import com.example.app.repo.VideoRepository;
 import com.example.app.service.ObjectUrlService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -23,6 +28,12 @@ public class VideoQueryController {
     public record HlsDto(String masterKey, String masterUrl, List<String> variants) {}
     public record VideoDetail(Long id, String title, String originalKey, HlsDto hls, List<ThumbDto> thumbnails) {}
 
+    @Operation(summary="Get video details", description="HLS/썸네일 presigned URL 포함")
+    @ApiResponses({
+            @ApiResponse(responseCode="200", description="ok"),
+            @ApiResponse(responseCode="404", description="not found",
+                    content=@Content(schema=@Schema(implementation=com.example.app.error.ErrorResponse.class)))
+    })
     @GetMapping("/{id}")
     public VideoDetail get(@PathVariable Long id) {
         var v = videos.findById(id).orElseThrow(() -> new NoSuchElementException("video not found: "+id));

--- a/app/src/main/java/com/example/app/controller/VideoUploadController.java
+++ b/app/src/main/java/com/example/app/controller/VideoUploadController.java
@@ -4,6 +4,9 @@ import com.example.app.service.UploadPostService;
 import com.example.app.service.ObjectKeyPolicy;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.*;
 
 import java.util.Map;
 
@@ -22,6 +25,14 @@ public class VideoUploadController {
     public record UploadInfo(String method, String url, Map<String,String> formFields, String objectKey, long expiresSeconds) {}
     public record CreateVideoResponse(Long videoId, UploadInfo upload) {}
 
+    @Operation(summary = "Create video & Presigned upload", description = "비디오 등록 후 Presigned 업로드 정보 반환")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "created"),
+            @ApiResponse(responseCode = "400", description = "validation error",
+                    content = @Content(schema = @Schema(implementation = com.example.app.error.ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "unauthorized",
+                    content = @Content(schema = @Schema(implementation = com.example.app.error.ErrorResponse.class)))
+    })
     @PostMapping
     public CreateVideoResponse createUploadForm(@RequestBody CreateVideoRequest req) {
         // ... video 엔티티 생성/저장 (생략, 기존 로직)

--- a/app/src/main/java/com/example/app/error/ApiExceptionHandler.java
+++ b/app/src/main/java/com/example/app/error/ApiExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.example.app.error;
+
+import jakarta.validation.ConstraintViolationException;
+import org.slf4j.MDC;
+import org.springframework.http.*;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    private ResponseEntity<ErrorResponse> build(int status, String code, String msg, Map<String,Object> details) {
+        String trace = MDC.get("traceId");
+        var body = ErrorResponse.builder()
+                .status(status).code(code).message(msg).traceId(trace).details(details).build();
+        return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON).body(body);
+    }
+
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<ErrorResponse> handleApp(AppException ex) {
+        return build(ex.httpStatus(), ex.code(), ex.getMessage(), null);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleInvalid(MethodArgumentNotValidException ex) {
+        var fields = ex.getBindingResult().getFieldErrors().stream().map(fe -> Map.of(
+                "field", fe.getField(), "message", fe.getDefaultMessage()
+        )).toList();
+        return build(400, "VALIDATION_ERROR", "validation failed", Map.of("fieldErrors", fields));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraint(ConstraintViolationException ex) {
+        var list = ex.getConstraintViolations().stream().map(v -> Map.of(
+                "property", v.getPropertyPath().toString(), "message", v.getMessage()
+        )).toList();
+        return build(400, "VALIDATION_ERROR", "validation failed", Map.of("violations", list));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NoSuchElementException ex) {
+        return build(404, "VIDEO_NOT_FOUND", ex.getMessage(), null);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAny(Exception ex) {
+        return build(500, "INTERNAL_ERROR", "unexpected error", Map.of("reason", ex.getClass().getSimpleName()));
+    }
+}

--- a/app/src/main/java/com/example/app/error/AppException.java
+++ b/app/src/main/java/com/example/app/error/AppException.java
@@ -1,0 +1,12 @@
+package com.example.app.error;
+
+public class AppException extends RuntimeException {
+    private final String code; private final int httpStatus;
+    public AppException(String code, int httpStatus, String message) {
+        super(message); this.code=code; this.httpStatus=httpStatus;
+    }
+    public String code(){ return code; } public int httpStatus(){ return httpStatus; }
+    public static AppException badRequest(String code, String msg){ return new AppException(code, 400, msg); }
+    public static AppException notFound(String code, String msg){ return new AppException(code, 404, msg); }
+    public static AppException conflict(String code, String msg){ return new AppException(code, 409, msg); }
+}

--- a/app/src/main/java/com/example/app/error/ErrorJsonWriter.java
+++ b/app/src/main/java/com/example/app/error/ErrorJsonWriter.java
@@ -1,0 +1,22 @@
+package com.example.app.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.MDC;
+import jakarta.servlet.http.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class ErrorJsonWriter {
+    private static final ObjectMapper om = new ObjectMapper();
+    public static void write(HttpServletResponse w, int status, String code, String msg, Map<String,Object> details) {
+        try {
+            var body = ErrorResponse.builder()
+                    .status(status).code(code).message(msg).traceId(MDC.get("traceId")).details(details).build();
+            var json = om.writeValueAsString(body);
+            w.setStatus(status);
+            w.setContentType("application/json");
+            w.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            w.getWriter().write(json);
+        } catch (Exception ignored) {}
+    }
+}

--- a/app/src/main/java/com/example/app/error/ErrorResponse.java
+++ b/app/src/main/java/com/example/app/error/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.example.app.error;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ErrorResponse(
+        Instant timestamp,
+        int status,
+        String code,
+        String message,
+        String traceId,
+        Map<String, Object> details
+) {
+    public static Builder builder() { return new Builder(); }
+    public static class Builder {
+        private int status; private String code; private String message; private String traceId;
+        private Map<String,Object> details;
+        public Builder status(int s){ this.status=s; return this; }
+        public Builder code(String c){ this.code=c; return this; }
+        public Builder message(String m){ this.message=m; return this; }
+        public Builder traceId(String t){ this.traceId=t; return this; }
+        public Builder details(Map<String,Object> d){ this.details=d; return this; }
+        public ErrorResponse build() {
+            return new ErrorResponse(Instant.now(), status, code, message, traceId, details);
+        }
+    }
+}

--- a/app/src/main/java/com/example/app/error/ErrorSchemas.java
+++ b/app/src/main/java/com/example/app/error/ErrorSchemas.java
@@ -1,0 +1,9 @@
+package com.example.app.error;
+
+import io.swagger.v3.oas.annotations.media.*;
+
+@Schema(name = "ErrorResponse")
+public class ErrorSchemas {
+    @Schema(description="Error response model", implementation = ErrorResponse.class)
+    public static class ErrorResponseSchema {}
+}

--- a/app/src/main/java/com/example/app/ratelimit/EnqueueRateLimitFilter.java
+++ b/app/src/main/java/com/example/app/ratelimit/EnqueueRateLimitFilter.java
@@ -1,5 +1,6 @@
 package com.example.app.ratelimit;
 
+import com.example.app.error.ErrorJsonWriter;
 import com.example.app.security.ApiKeyAuthFilter;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
@@ -38,9 +39,9 @@ public class EnqueueRateLimitFilter implements Filter {
         if (!v.allowed()) {
             long retrySec = (long) Math.ceil(v.retryAfterMs() / 1000.0);
             w.setHeader("Retry-After", String.valueOf(retrySec));
-            w.setStatus(429);
-            w.setContentType("application/json");
-            w.getWriter().write("{\"status\":429,\"code\":\"RATE_LIMITED\",\"message\":\"too many requests\"}");
+            w.setHeader("X-RateLimit-Limit", String.valueOf(limiter.capacity()));
+            w.setHeader("X-RateLimit-Remaining", String.valueOf(Math.max(0, v.remaining())));
+            ErrorJsonWriter.write(w, 429, "RATE_LIMITED", "too many requests", null);
             return;
         }
         chain.doFilter(req, res);

--- a/app/src/main/java/com/example/app/security/ApiKeyAuthFilter.java
+++ b/app/src/main/java/com/example/app/security/ApiKeyAuthFilter.java
@@ -1,6 +1,7 @@
 package com.example.app.security;
 
 import com.example.app.config.SecurityProps;
+import com.example.app.error.ErrorJsonWriter;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import org.slf4j.MDC;
@@ -31,9 +32,7 @@ public class ApiKeyAuthFilter implements Filter {
         String key = r.getHeader(HEADER);
 
         if (key == null || key.isBlank() || !whitelist.contains(key)) {
-            w.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            w.setContentType("application/json");
-            w.getWriter().write("{\"status\":401,\"code\":\"UNAUTHORIZED\",\"message\":\"invalid api key\"}");
+            ErrorJsonWriter.write(w, 401, "UNAUTHORIZED", "invalid api key", null);
             return;
         }
 

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,30 +1,23 @@
 app:
   topics:
-    transcode-requests: transcode.requests        # 프로듀서가 보낼 토픽
-    transcode-results: transcode.results          # (필요 시)
+    transcode-requests: transcode.requests
+    transcode-results: transcode.results
 
 spring:
+  config:
+    import: optional:file:.env
+
   datasource:
     url: jdbc:mysql://localhost:3306/ott
     username: root
     password: 1234
-
-  config:
-    import: optional:file:.env
 
   flyway:
     enabled: true
     url: ${spring.datasource.url}
     user: ${spring.datasource.username}
     password: ${spring.datasource.password}
-    locations: classpath:db/migration  # 기본값이긴 한데 명시해두면 좋아
-    # 기존 테이블 있는 상태에서 처음 적용이면만 ↓ 켜기
-    # baseline-on-migrate: true
-
-  logging:
-    level:
-      org.flywaydb: DEBUG   # 어떤 DB로 붙는지 로그로 확인용(임시)
-
+    locations: classpath:db/migration
 
   jpa:
     hibernate:
@@ -38,20 +31,11 @@ spring:
     multipart:
       max-file-size: 1GB
       max-request-size: 1GB
+
   data:
     redis:
       host: localhost
       port: 6379
-
-rate-limit:
-  enqueue:
-    capacity: 10         # 버스트 최대 토큰
-    refillPerSec: 5      # 초당 보충 토큰 수 (QPS 비슷한 개념)
-
-security:
-  api-keys:               # 임시 화이트리스트(실무는 DB/인증서버)
-    - alice-key
-    - bob-key
 
   kafka:
     bootstrap-servers: localhost:9094
@@ -72,6 +56,16 @@ security:
       properties:
         spring.json.trusted.packages: "*"
 
+rate-limit:
+  enqueue:
+    capacity: 10
+    refillPerSec: 5
+
+security:
+  api-keys:
+    - alice-key
+    - bob-key
+
 management:
   endpoints:
     web:
@@ -90,3 +84,7 @@ storage:
 
 server:
   port: 8080
+
+logging:
+  level:
+    org.flywaydb: DEBUG


### PR DESCRIPTION
## Summary
- 에러 응답 규격 **단일 포맷(ErrorResponse)** 도입 및 코드 맵 문서화
- 공통 예외 핸들러(@ControllerAdvice)로 에러 형태 통일
- Swagger(OpenAPI) 스키마/응답 코드/예시 추가
- README에 **10분 로컬 실행 Runbook** + 아키텍처/운영 가이드 보강

## Changes
### 앱 코드
- `ErrorResponse`, `AppException`, `GlobalExceptionHandler`, `ErrorJsonWriter` 추가
- 컨트롤러에 OpenAPI 어노테이션(`@Operation`, `@ApiResponses`) 반영
- `OpenApiConfig`로 기본 메타(title/version/desc)

### 문서
- `docs/error-map.md`: 에러코드 표(HTTP/설명/클라이언트 액션) + 공통 포맷
- `README.md`: 인프라 기동 → 앱/워커 실행 → Swagger → 업로드/큐/조회 TL;DR

## API Error Format (표준)
```json
{
  "timestamp": "2025-09-12T03:21:34.123Z",
  "status": 429,
  "code": "RATE_LIMITED",
  "message": "too many requests",
  "traceId": "2b3d...e91",
  "details": { "fieldErrors": [ { "field":"title", "message":"must not be blank" } ] }
}
